### PR TITLE
Fix settings cast

### DIFF
--- a/src/Listeners/InjectSettings.php
+++ b/src/Listeners/InjectSettings.php
@@ -30,8 +30,8 @@ class InjectSettings
         if ($event->serializer instanceof ForumSerializer) {
             // Dispatcher not yet available if we're using IoC in construct.
             $fields = app(FieldRepository::class);
-            $event->attributes['masquerade.force-profile-completion'] = $this->settings->get('masquerade.force-profile-completion', false);
-            $event->attributes['masquerade.disable-user-bio'] = $this->settings->get('masquerade.disable-user-bio', false);
+            $event->attributes['masquerade.force-profile-completion'] = (bool) $this->settings->get('masquerade.force-profile-completion', false);
+            $event->attributes['masquerade.disable-user-bio'] = (bool) $this->settings->get('masquerade.disable-user-bio', false);
             $event->attributes['masquerade.profile-completed'] = $event->actor && $event->actor->id ? $fields->completed($event->actor->id) : false;
         }
     }


### PR DESCRIPTION
Fixes #10

I think this fix is better than #12 because we don't have to mess with javascript at all, the attribute is casted right when it comes out of the database