### PR TITLE
CSS Tweak & Short URL

### DIFF
--- a/js/admin/dist/extension.js
+++ b/js/admin/dist/extension.js
@@ -7,7 +7,7 @@ System.register("flagrow/masquerade/addProfileConfigurePane", ["flarum/extend", 
 
     _export("default", function () {
         // create the route
-        app.routes['flagrow-masquerade-configure-profile'] = { path: '/flagrow/masquerade/configure', component: ProfileConfigurePane.component() };
+        app.routes['flagrow-masquerade-configure-profile'] = { path: '/masquerade', component: ProfileConfigurePane.component() };
 
         // bind the route we created to the three dots settings button
         app.extensionSettings['flagrow-masquerade'] = function () {
@@ -264,10 +264,22 @@ System.register("flagrow/masquerade/panes/ProfileConfigurePane", ["flarum/Compon
                             className: 'Field',
                             'data-id': field.id()
                         }, [m('legend', [exists ? m('div', { className: 'ButtonGroup pull-right' }, [Button.component({
+                            className: 'Button Button--icon',
+                            icon: "pencil-square-o",
+                            onclick: function onclick(e) {
+                                return _this4.toggleField(e);
+                            }
+                        })], [Button.component({
                             className: 'Button Button--icon Button--danger',
                             icon: "trash",
                             onclick: this.deleteField.bind(this, field)
-                        })]) : null, m('span', {
+                        })]) : m('div', { className: 'ButtonGroup pull-right' }, [Button.component({
+                            className: 'Button Button--icon',
+                            icon: "plus",
+                            onclick: function onclick(e) {
+                                return _this4.toggleField(e);
+                            }
+                        })]), m('span', {
                             className: 'title',
                             onclick: function onclick(e) {
                                 return _this4.toggleField(e);

--- a/js/admin/src/addProfileConfigurePane.js
+++ b/js/admin/src/addProfileConfigurePane.js
@@ -5,7 +5,7 @@ import ProfileConfigurePane from 'flagrow/masquerade/panes/ProfileConfigurePane'
 
 export default function () {
     // create the route
-    app.routes['flagrow-masquerade-configure-profile'] = {path: '/flagrow/masquerade/configure', component: ProfileConfigurePane.component()};
+    app.routes['flagrow-masquerade-configure-profile'] = {path: '/masquerade', component: ProfileConfigurePane.component()};
 
     // bind the route we created to the three dots settings button
     app.extensionSettings['flagrow-masquerade'] = () => m.route(app.route('flagrow-masquerade-configure-profile'));

--- a/js/admin/src/panes/ProfileConfigurePane.js
+++ b/js/admin/src/panes/ProfileConfigurePane.js
@@ -117,12 +117,27 @@ export default class ProfileConfigurePane extends Component {
         }, [
             m('legend', [
                 exists ? m('div', {className: 'ButtonGroup pull-right'}, [
+					Button.component({
+                            className: 'Button Button--icon',
+                            icon: "pencil-square-o",
+                            onclick: function onclick(e) {
+                                return _this4.toggleField(e);
+                            }
+                    })], [
                     Button.component({
                         className: 'Button Button--icon Button--danger',
                         icon: "trash",
                         onclick: this.deleteField.bind(this, field)
                     })
-                ]) : null,
+                ]) : m('div', { className: 'ButtonGroup pull-right' }, [
+						Button.component({
+                            className: 'Button Button--icon',
+                            icon: "plus",
+                            onclick: function onclick(e) {
+                                return _this4.toggleField(e);
+                            }
+                        })]
+					),
                 m(
                     'span', {
                         className: 'title',

--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -1,54 +1,80 @@
 'use strict';
 
-System.register('flagrow/masquerade/addProfilePane', ['flarum/extend', 'flagrow/masquerade/panes/ProfilePane', 'flagrow/masquerade/panes/ProfileConfigurePane', 'flarum/components/UserPage', 'flarum/components/LinkButton'], function (_export, _context) {
-  "use strict";
+System.register('flagrow/masquerade/addProfileConfigurePane', ['flarum/extend', 'flagrow/masquerade/panes/ProfileConfigurePane', 'flarum/components/UserPage', 'flarum/components/LinkButton'], function (_export, _context) {
+    "use strict";
 
-  var extend, ProfilePane, ProfileConfigurePane, UserPage, LinkButton;
+    var extend, ProfileConfigurePane, UserPage, LinkButton;
 
-  _export('default', function () {
-    app.routes['flagrow-masquerade-view-profile'] = {
-      path: '/masquerade/:username',
-      component: ProfilePane.component()
-    };
-    app.routes['masquerade-configure-profile'] = {
-      path: '/masquerade/configure',
-      component: ProfileConfigurePane.component()
-    };
+    _export('default', function () {
+        // create the route
+        app.routes['masquerade-configure-profile'] = { path: '/profile/configure', component: ProfileConfigurePane.component() };
 
-    extend(UserPage.prototype, 'navItems', function (items) {
-      if (app.forum.attribute('canViewMasquerade') || app.forum.attribute('canHaveMasquerade')) {
-        var user = this.user;
-        var href = app.forum.attribute('canHaveMasquerade') && app.session.user === user ? app.route('masquerade-configure-profile') : app.route('flagrow-masquerade-view-profile', { username: user.username() });
-        items.add('masquerade', LinkButton.component({
-          href: href,
-          children: app.translator.trans('flagrow-masquerade.forum.buttons.view-profile'),
-          icon: 'id-card-o'
-        }), 200);
-      }
+        extend(UserPage.prototype, 'navItems', function (items) {
+            if (app.forum.attribute('canHaveMasquerade') && app.session.user === this.user) {
+                items.add('masquerade-configure', LinkButton.component({
+                    href: app.route('masquerade-configure-profile'),
+                    children: app.translator.trans('flagrow-masquerade.forum.buttons.configure-profile'),
+                    icon: 'id-card-o'
+                }), -100);
+            }
+        });
     });
-  });
 
-  return {
-    setters: [function (_flarumExtend) {
-      extend = _flarumExtend.extend;
-    }, function (_flagrowMasqueradePanesProfilePane) {
-      ProfilePane = _flagrowMasqueradePanesProfilePane.default;
-    }, function (_flagrowMasqueradePanesProfileConfigurePane) {
-      ProfileConfigurePane = _flagrowMasqueradePanesProfileConfigurePane.default;
-    }, function (_flarumComponentsUserPage) {
-      UserPage = _flarumComponentsUserPage.default;
-    }, function (_flarumComponentsLinkButton) {
-      LinkButton = _flarumComponentsLinkButton.default;
-    }],
-    execute: function () {}
-  };
+    return {
+        setters: [function (_flarumExtend) {
+            extend = _flarumExtend.extend;
+        }, function (_flagrowMasqueradePanesProfileConfigurePane) {
+            ProfileConfigurePane = _flagrowMasqueradePanesProfileConfigurePane.default;
+        }, function (_flarumComponentsUserPage) {
+            UserPage = _flarumComponentsUserPage.default;
+        }, function (_flarumComponentsLinkButton) {
+            LinkButton = _flarumComponentsLinkButton.default;
+        }],
+        execute: function () {}
+    };
+});;
+'use strict';
+
+System.register('flagrow/masquerade/addProfilePane', ['flarum/extend', 'flagrow/masquerade/panes/ProfilePane', 'flarum/components/UserPage', 'flarum/components/LinkButton'], function (_export, _context) {
+    "use strict";
+
+    var extend, ProfilePane, UserPage, LinkButton;
+
+    _export('default', function () {
+        // create the route
+        app.routes['flagrow-masquerade-view-profile'] = { path: '/u/:username/profile', component: ProfilePane.component() };
+
+        extend(UserPage.prototype, 'navItems', function (items) {
+            if (app.forum.attribute('canViewMasquerade')) {
+                var user = this.user;
+                items.add('masquerade', LinkButton.component({
+                    href: app.route('flagrow-masquerade-view-profile', { username: user.username() }),
+                    children: app.translator.trans('flagrow-masquerade.forum.buttons.view-profile'),
+                    icon: 'id-card-o'
+                }), 200);
+            }
+        });
+    });
+
+    return {
+        setters: [function (_flarumExtend) {
+            extend = _flarumExtend.extend;
+        }, function (_flagrowMasqueradePanesProfilePane) {
+            ProfilePane = _flagrowMasqueradePanesProfilePane.default;
+        }, function (_flarumComponentsUserPage) {
+            UserPage = _flarumComponentsUserPage.default;
+        }, function (_flarumComponentsLinkButton) {
+            LinkButton = _flarumComponentsLinkButton.default;
+        }],
+        execute: function () {}
+    };
 });;
 "use strict";
 
-System.register("flagrow/masquerade/main", ["flarum/extend", "flarum/app", "flarum/models/User", "flagrow/masquerade/models/Field", "flagrow/masquerade/models/Answer", "flarum/Model", "flagrow/masquerade/addProfilePane", "flagrow/masquerade/mutateUserBio"], function (_export, _context) {
+System.register("flagrow/masquerade/main", ["flarum/extend", "flarum/app", "flarum/models/User", "flagrow/masquerade/models/Field", "flagrow/masquerade/models/Answer", "flarum/Model", "flagrow/masquerade/addProfileConfigurePane", "flagrow/masquerade/addProfilePane", "flagrow/masquerade/mutateUserBio"], function (_export, _context) {
     "use strict";
 
-    var extend, app, User, Field, Answer, Model, addProfilePane, mutateUserBio;
+    var extend, app, User, Field, Answer, Model, addProfileConfigurePane, addProfilePane, mutateUserBio;
     return {
         setters: [function (_flarumExtend) {
             extend = _flarumExtend.extend;
@@ -62,6 +88,8 @@ System.register("flagrow/masquerade/main", ["flarum/extend", "flarum/app", "flar
             Answer = _flagrowMasqueradeModelsAnswer.default;
         }, function (_flarumModel) {
             Model = _flarumModel.default;
+        }, function (_flagrowMasqueradeAddProfileConfigurePane) {
+            addProfileConfigurePane = _flagrowMasqueradeAddProfileConfigurePane.default;
         }, function (_flagrowMasqueradeAddProfilePane) {
             addProfilePane = _flagrowMasqueradeAddProfilePane.default;
         }, function (_flagrowMasqueradeMutateUserBio) {
@@ -75,6 +103,7 @@ System.register("flagrow/masquerade/main", ["flarum/extend", "flarum/app", "flar
 
                 User.prototype.bioFields = Model.hasMany('bioFields');
 
+                addProfileConfigurePane();
                 addProfilePane();
 
                 mutateUserBio();
@@ -106,7 +135,7 @@ System.register('flagrow/masquerade/models/Answer', ['flarum/Model', 'flarum/uti
                 babelHelpers.createClass(Answer, [{
                     key: 'apiEndpoint',
                     value: function apiEndpoint() {
-                        return '/masquerade/configure' + (this.exists ? '/' + this.data.id : '');
+                        return '/profile/configure' + (this.exists ? '/' + this.data.id : '');
                     }
                 }]);
                 return Answer;
@@ -144,7 +173,7 @@ System.register('flagrow/masquerade/models/Field', ['flarum/Model', 'flarum/util
                 babelHelpers.createClass(Field, [{
                     key: 'apiEndpoint',
                     value: function apiEndpoint() {
-                        return '/masquerade/fields' + (this.exists ? '/' + this.data.id : '');
+                        return '/profile/fields' + (this.exists ? '/' + this.data.id : '');
                     }
                 }]);
                 return Field;
@@ -273,7 +302,7 @@ System.register("flagrow/masquerade/panes/ProfileConfigurePane", ["flarum/compon
                     value: function load() {
                         app.request({
                             method: 'GET',
-                            url: app.forum.attribute('apiUrl') + '/masquerade/configure'
+                            url: app.forum.attribute('apiUrl') + '/profile/configure'
                         }).then(this.parseResponse.bind(this));
                     }
                 }, {
@@ -295,7 +324,7 @@ System.register("flagrow/masquerade/panes/ProfileConfigurePane", ["flarum/compon
 
                         app.request({
                             method: 'POST',
-                            url: app.forum.attribute('apiUrl') + '/masquerade/configure',
+                            url: app.forum.attribute('apiUrl') + '/profile/configure',
                             data: data
                         }).then(this.parseResponse.bind(this));
                     }
@@ -375,7 +404,7 @@ System.register("flagrow/masquerade/panes/ProfilePane", ["flarum/components/User
                     value: function load(user) {
                         app.request({
                             method: 'GET',
-                            url: app.forum.attribute('apiUrl') + '/masquerade/profile/' + user.id()
+                            url: app.forum.attribute('apiUrl') + '/u/:username/profile/' + user.id()
                         }).then(this.parseResponse.bind(this));
                     }
                 }, {

--- a/js/forum/src/addProfilePane.js
+++ b/js/forum/src/addProfilePane.js
@@ -6,11 +6,11 @@ import LinkButton from 'flarum/components/LinkButton';
 
 export default function () {
   app.routes['flagrow-masquerade-view-profile'] = {
-    path: '/masquerade/:username',
+    path: '/u/:username/profile',
     component: ProfilePane.component()
   };
   app.routes['masquerade-configure-profile'] = {
-    path: '/masquerade/configure',
+    path: '/profile/configure',
     component: ProfileConfigurePane.component()
   };
 

--- a/js/forum/src/panes/ProfileConfigurePane.js
+++ b/js/forum/src/panes/ProfileConfigurePane.js
@@ -65,7 +65,7 @@ export default class ProfileConfigurePane extends UserPage {
     load() {
         app.request({
             method: 'GET',
-            url: app.forum.attribute('apiUrl') + '/masquerade/configure',
+            url: app.forum.attribute('apiUrl') + '/profile/configure',
         }).then(
             this.parseResponse.bind(this)
         );
@@ -87,7 +87,7 @@ export default class ProfileConfigurePane extends UserPage {
 
         app.request({
             method: 'POST',
-            url: app.forum.attribute('apiUrl') + '/masquerade/configure',
+            url: app.forum.attribute('apiUrl') + '/profile/configure',
             data
         }).then(
             this.parseResponse.bind(this)

--- a/js/forum/src/panes/ProfilePane.js
+++ b/js/forum/src/panes/ProfilePane.js
@@ -44,7 +44,7 @@ export default class ProfileConfigurePane extends UserPage {
     load(user) {
         app.request({
             method: 'GET',
-            url: app.forum.attribute('apiUrl') + '/masquerade/profile/' + user.id(),
+            url: app.forum.attribute('apiUrl') + '/u/:username/profile/' + user.id(),
         }).then(
             this.parseResponse.bind(this)
         );

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -1,19 +1,22 @@
 .ProfileConfigurePane {
-    background: @control-bg;
+    background: @body-bg;
     color: @control-color;
     min-height: 100vh;
     padding: 20px 0;
-
     fieldset.Field {
         padding: 5px;
-        background: @body-bg;
+        background: @control-color;
         border-radius: @border-radius;
+		margin-bottom: 15px;
         legend {
-            margin: 10px;
-            width: 100%;
+			margin: -5px;
+            width: 102%;
+			background: @control-bg;
+			border-radius: @border-radius;
             > span {
+				padding-left: 13px;
                 cursor: pointer;
-            }
+			}
         }
         > ul {
             margin-bottom: 30px;
@@ -24,9 +27,12 @@
             > li {
                 margin: 8px 0;
                 display: block;
-
                 > label {
                     font-weight: bold;
+					color: @control-bg;
+                }
+				> span {
+					color: @control-bg;
                 }
             }
         }
@@ -34,7 +40,6 @@
             display: block;
         }
     }
-
     @media @desktop-up {
         .container {
             max-width: 600px;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,27 +1,21 @@
 .ProfileConfigurePane {
     min-height: 100vh;
     padding: 20px 0;
-
     .Fields {
         margin: 10px 0;
-
         fieldset.Field {
+			max-width: 500px;
             margin: 0 5px;
             padding: 5px;
-
+			margin-bottom: 8px;
             legend {
                 margin: 10px 10px 0;
                 width: 100%;
-                > span {
-                    cursor: pointer;
-                }
             }
-
             .FormField {
                 .prefix {
                     float: left;
                     width: 30%;
-
                     display: block;
                     height: 36px;
                     padding: 8px 13px;
@@ -36,7 +30,6 @@
             }
         }
     }
-
     @media @desktop-up {
         .container {
             max-width: 600px;
@@ -44,20 +37,22 @@
         }
     }
 }
-
-
+.ProfileConfigurePane i, .Masquerade-Bio i {margin-right: 5px;}
 .Masquerade-Bio {
     .Masquerade-Bio-Set {
         width: 100%;
+		border-bottom: 3px solid @control-bg;
+		margin-bottom: 10px;
         .Masquerade-Bio-Field {
             display: inline-block;
             padding: .1em .2em;
             font-weight: bold;
             min-width: 30%;
+			vertical-align: top;
         }
         .Masquerade-Bio-Answer {
             display: inline-block;
-            width: 50%;
+            width: 70%;
         }
     }
 }

--- a/src/Listeners/AddApiRoutes.php
+++ b/src/Listeners/AddApiRoutes.php
@@ -38,8 +38,8 @@ class AddApiRoutes
         /**
          * Forum side
          */
-        $routes->get('/masquerade/profile/{id:[0-9]+}', 'masquerade.api.profile', UserProfileController::class);
-        $routes->get('/masquerade/configure', 'masquerade.api.configure', UserConfigureController::class);
-        $routes->post('/masquerade/configure', 'masquerade.api.configure.save', UserConfigureController::class);
+        $routes->get('/u/{username}/profile/{id:[0-9]+}', 'masquerade.api.profile', UserProfileController::class);
+        $routes->get('/profile/configure', 'masquerade.api.configure', UserConfigureController::class);
+        $routes->post('/profile/configure', 'masquerade.api.configure.save', UserConfigureController::class);
     }
 }

--- a/src/Listeners/AddWebRoutes.php
+++ b/src/Listeners/AddWebRoutes.php
@@ -23,12 +23,12 @@ class AddWebRoutes
     public function routes(ConfigureForumRoutes $routes)
     {
         $routes->get(
-            '/masquerade/configure',
+            '/profile/configure',
             'masquerade.profile.configure',
             ManageProfileController::class
         );
         $routes->get(
-            '/masquerade/{username}',
+            '/u/{username}/profile',
             'masquerade.profile.view',
             ViewProfileController::class
         );


### PR DESCRIPTION
Modification CSS & Add two icons in admin side!
URL change : 
- Forum side become : "/u/{user}/profile" & "/profile/configure".
- Admin side, I just take out the "flagrow" and "config." so it's "/masquerade" only !!

*As always, don't forget to proofread, in case I missed some shit!*
(See on : [Flarum Discussion](https://discuss.flarum.org/d/5791-flagrow-masquerade-user-profile-builder/27))